### PR TITLE
EOS-28388: fetch data from bytecount btree

### DIFF
--- a/spiel/ut/spiel_ci_ut.c
+++ b/spiel/ut/spiel_ci_ut.c
@@ -528,6 +528,7 @@ void test_spiel_bc_stats(void)
 	spiel_ci_ut_init();
 
 	M0_SET0(&count_stats);
+	m0_fi_enable_once("ss_bytecount_stats_ingest", "dummy_bytecount_data");
 	rc = m0_spiel_proc_counters_fetch(&spiel, &proc_fid, &count_stats);
 
 	M0_UT_ASSERT(m0_fid_eq(&count_stats.pc_proc_fid, &proc_fid));

--- a/sss/process_fops.h
+++ b/sss/process_fops.h
@@ -127,6 +127,10 @@ struct m0_ss_process_rep {
 	 * Buffer which holds records from bytecount btree
 	 */
 	struct m0_buf sspr_bcrec;
+	/**
+	 * Number of key values in key and record buffers
+	 */
+	uint32_t      sspr_kv_count;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 struct m0_ss_process_svc_item {


### PR DESCRIPTION
sss foms now make m0_cob_bc_entries_dump() calls to populate
reply fop key record buffers with bytecount data from bytecount btree.

Changed implementation of spiel API m0_spiel_proc_counters_fetch() to
accept data from btree instead of hardcoded data.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
